### PR TITLE
Fix include for GCC11

### DIFF
--- a/src/include/librtprocess.h
+++ b/src/include/librtprocess.h
@@ -21,6 +21,7 @@
 #define _LIBRTPROCESS_
 
 #include <functional>
+#include <cstddef>
 
 
 enum rpError {RP_NO_ERROR, RP_MEMORY_ERROR, RP_WRONG_CFA, RP_CACORRECT_ERROR};


### PR DESCRIPTION
This fixes build with GCC11 on Fedora.